### PR TITLE
fix: add backoff sleep between request retries to prevent HA event loop block

### DIFF
--- a/custom_components/zidoo/zidooaio.py
+++ b/custom_components/zidoo/zidooaio.py
@@ -474,6 +474,7 @@ class ZidooRC:
 
             if max_retries > 0:
                 _LOGGER.warning("[W] Retry %d: url:%s", max_retries, url)
+                await asyncio.sleep(0.5)
             max_retries -= 1
 
         # clear cookies to show not connected


### PR DESCRIPTION
## Summary

Adds a single `await asyncio.sleep(0.5)` between request retries in `ZidooRC._req_json` to prevent a sub-millisecond retry burst from blocking the Home Assistant event loop when the Zidoo player is unreachable.

## Background

When the Zidoo player becomes unreachable (e.g. immediately after a `remote.turn_off`, or when the device drops Wi-Fi), the OS returns `ECONNREFUSED` on TCP connect synchronously — there is no SYN timeout to throttle reconnection. The current retry loop in `ZidooRC._req_json` re-enters `_send_cmd` with no delay between attempts, burning through all 3 retries in well under 1 ms.

When the coordinator polls multiple URLs concurrently (`getInputAndOutputList`, `getPlayStatus`, `getState`), this produces ~9 sub-millisecond retry warnings in tight succession. Under load — e.g. when a theater automation is also driving MadVR, Anthem, JVC, lighting groups — the resulting event-loop pressure can starve the Supervisor watchdog ping long enough for the Supervisor to declare HA Core unhealthy and forcibly restart the homeassistant container.

## Reproduction

1. Configure an automation that powers off the Zidoo via `remote.turn_off` while the integration is actively polling.
2. Observe the log emitting the entire retry burst in <10 ms:

```
2026-05-15 18:09:50.144 WARNING [custom_components.zidoo.zidooaio] [W] Retry 3: url:ZidooMusicControl/v2/getInputAndOutputList
2026-05-15 18:09:50.145 WARNING [custom_components.zidoo.zidooaio] [W] Retry 2: url:ZidooMusicControl/v2/getInputAndOutputList
2026-05-15 18:09:50.145 WARNING [custom_components.zidoo.zidooaio] [W] Retry 1: url:ZidooMusicControl/v2/getInputAndOutputList
2026-05-15 18:09:50.146 DEBUG   [custom_components.zidoo.zidooaio] No response from player! Showing not connected
2026-05-15 18:09:50.147 WARNING [custom_components.zidoo.zidooaio] [W] Retry 3: url:ZidooVideoPlay/getPlayStatus
2026-05-15 18:09:50.147 WARNING [custom_components.zidoo.zidooaio] [W] Retry 2: url:ZidooVideoPlay/getPlayStatus
2026-05-15 18:09:50.148 WARNING [custom_components.zidoo.zidooaio] [W] Retry 1: url:ZidooVideoPlay/getPlayStatus
2026-05-15 18:09:50.149 WARNING [custom_components.zidoo.zidooaio] [W] Retry 3: url:ZidooMusicControl/v2/getState
2026-05-15 18:09:50.150 WARNING [custom_components.zidoo.zidooaio] [W] Retry 2: url:ZidooMusicControl/v2/getState
2026-05-15 18:09:50.150 WARNING [custom_components.zidoo.zidooaio] [W] Retry 1: url:ZidooMusicControl/v2/getState
```

3. Shortly after, the Supervisor declares HA Core unhealthy and restarts the container:

```
[supervisor.misc.tasks] Watchdog missed an Home Assistant Core API response.
[supervisor.homeassistant.core] Watchdog found Home Assistant failed, restarting...
```

In my environment, this caused a 2m22s container outage every time the theater-off automation ran.

## The fix

```diff
             if max_retries > 0:
                 _LOGGER.warning("[W] Retry %d: url:%s", max_retries, url)
+                await asyncio.sleep(0.5)
             max_retries -= 1
```

- Worst-case added latency per failed request: 3 × 0.5s = 1.5s.
- Coordinator debouncer cooldown is already 1.0s (`coordinator.py`), and the rapid scan interval is 1.0s — so the added delay does not pile up across cycles.
- On the success path no sleep is added; happy-path performance is unchanged.
- The sleep gives the event loop a real opportunity to run other tasks instead of being monopolized by tight reconnection attempts.

## Test plan

- Power off the Zidoo via `remote.turn_off` while polling is active.
- Observe retry warnings spaced ~500 ms apart instead of <1 ms.
- Confirm Supervisor watchdog no longer fires (`Watchdog missed an Home Assistant Core API response.` should no longer appear).
- Confirm normal media-playing state polling and command latency are unchanged.

Happy to adjust the sleep duration or make it configurable if preferred — 0.5s is the smallest value I'd be comfortable with for general use.